### PR TITLE
chore: clean ci/chore leakage from v0.1.0/v0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,6 @@
 
 - feat: updates @Bugs5382 (#23)
 
-#### 🐛 Bug Fixes
-
-- feat: updates @Bugs5382 (#23)
-
-#### 📄 Documentation
-
-- feat: updates @Bugs5382 (#23)
-
 ### Extra
 
 **Full Changelog**: https://github.com/Bugs5382/helm-technitium-chart/compare/v0.1.0...v0.2.0
@@ -26,18 +18,12 @@
 
 #### 🚀 Features
 
-- chore: cleanup and update config options @Bugs5382 (#17)
 - feat: added all env @Bugs5382 (#13)
-- ci: updated release-drafter version @Bugs5382 (#9)
-- ci: more fixes (#6) @Bugs5382 (#7)
 - feat: helm chart creation @Bugs5382 (#2)
 
 #### 🐛 Bug Fixes
 
-- ci: fix release steps @Bugs5382 (#15)
 - fix: updated pvc vol mount @Bugs5382 (#11)
-- ci: more fixes (#6) @Bugs5382 (#7)
-- ci: fix (#4) @Bugs5382 (#5)
 
 ### Extra
 


### PR DESCRIPTION
## What and why

v0.1.0 listed `ci:`/`chore:` PRs (#5, #7, #9, #15, #17) under Features/Bug Fixes, and v0.2.0 listed PR #23 three times because it carried bug + documentation + enhancement. These predate the deterministic label-checker.

The PRs are now relabeled (ci/chore to `skip-changelog`; #23 to `enhancement` only), and this trims CHANGELOG.md to match. The published v0.1.0/v0.2.0 release bodies will be corrected separately.

Closes #28

## Verification

- [x] v0.1.0 shows only feat/fix entries; v0.2.0 lists #23 once
- [ ] Historical PR labels corrected (done via gh)

## How this was verified

Reviewed the rendered CHANGELOG.md sections after the edit.