### PR TITLE
feat: enforce Recreate update strategy (reject RollingUpdate)

### DIFF
--- a/technitium/templates/deployment.yaml
+++ b/technitium/templates/deployment.yaml
@@ -28,11 +28,17 @@ metadata:
     {{- include "technitium.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  # Recreate by default: the config/zone data lives on a single ReadWriteOnce PVC
-  # that cannot be mounted by two pods at once, so a RollingUpdate would deadlock.
-  # See `updateStrategy` in values.yaml. For zero-downtime updates use cluster mode.
+  # Recreate is mandatory: the config/zone data lives on a single ReadWriteOnce
+  # PVC that cannot be mounted by two pods at once, so a RollingUpdate deadlocks
+  # (the new pod stays Pending waiting for the volume). We reject any other
+  # strategy at render time rather than letting it deploy and hang. For
+  # multi-node high availability run separate releases in cluster mode.
+  {{- $strategyType := (.Values.updateStrategy | default dict).type | default "Recreate" }}
+  {{- if ne $strategyType "Recreate" }}
+  {{- fail (printf "updateStrategy.type must be \"Recreate\" (got %q): Technitium uses a single ReadWriteOnce PVC, so a RollingUpdate deadlocks. For multi-node high availability, run separate releases in cluster mode." $strategyType) }}
+  {{- end }}
   strategy:
-    {{- toYaml (.Values.updateStrategy | default (dict "type" "Recreate")) | nindent 4 }}
+    type: Recreate
   selector:
     matchLabels:
       {{- include "technitium.selectorLabels" . | nindent 6 }}

--- a/technitium/values.yaml
+++ b/technitium/values.yaml
@@ -77,20 +77,20 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: ""
 
-# Deployment update strategy.
+# Deployment update strategy. Recreate is REQUIRED and enforced at render time:
+# any other value fails `helm template`/`install` with a clear error.
 #
 # Technitium keeps its config and zone data on a single ReadWriteOnce PVC, which
-# Kubernetes will not mount on two pods at once. With the default RollingUpdate,
-# Kubernetes tries to start the new pod before the old one releases the volume,
-# so the rollout deadlocks (new pod stuck Pending). Recreate terminates the old
-# pod first, then starts the new one -- a brief DNS outage during the swap, but
-# no deadlock. This is the only safe single-replica option on a ReadWriteOnce
-# volume.
+# Kubernetes will not mount on two pods at once. With RollingUpdate, Kubernetes
+# tries to start the new pod before the old one releases the volume, so the
+# rollout deadlocks (new pod stuck Pending). Recreate terminates the old pod
+# first, then starts the new one -- a brief DNS outage during the swap, but no
+# deadlock. It is the only safe option on a ReadWriteOnce volume.
 #
-# For zero-downtime updates, run Technitium in cluster mode (see `cluster`
-# below): multiple instances, each with its own volume and external IP, where a
-# secondary syncs zones from the primary. Clients always have a live resolver, so
-# replicas can be rolled one at a time -- set `type: RollingUpdate` there.
+# For high availability without an update outage, run Technitium in cluster mode
+# (see `cluster` below): separate releases, each with its own instance, volume,
+# and external IP, where a secondary syncs zones from the primary, so one node
+# stays live while another restarts.
 updateStrategy:
   type: Recreate
 


### PR DESCRIPTION
## What and why

Technitium stores config/zone data on a single ReadWriteOnce PVC, so a Deployment with RollingUpdate deadlocks (the new pod stays Pending waiting for the volume the old pod still holds). The chart defaulted to Recreate, but a user could still set `updateStrategy.type: RollingUpdate` and footgun themselves.

This hard-fails `helm template`/`install` with a clear message for any non-Recreate strategy and always emits `type: Recreate`. StatefulSet was considered but dropped: multi-node clustering needs separate instances/external IPs (separate releases), which a single StatefulSet cannot provide, so cluster mode remains the HA path.

Closes #30

## Verification

- [x] `helm template` (default) renders `strategy.type: Recreate`
- [x] `helm template --set updateStrategy.type=RollingUpdate` fails with the guard message

## How this was verified

Ran both `helm template` invocations locally; confirmed the default renders Recreate and the RollingUpdate case errors at deployment.yaml with the explanatory message.